### PR TITLE
fix index of num_features_to_replace bug

### DIFF
--- a/lop/algos/convGnT.py
+++ b/lop/algos/convGnT.py
@@ -207,7 +207,7 @@ class ConvGnT(object):
         if self.opt_type == 'AdamGnT':
             for i in range(self.num_hidden_layers):
                 # input weights
-                if num_features_to_replace == 0:
+                if num_features_to_replace[i] == 0:
                     continue
                 # input weights
                 self.opt.state[self.net[i * 2].bias]['exp_avg'][features_to_replace_input_indices[i]] = 0.0

--- a/lop/algos/gnt.py
+++ b/lop/algos/gnt.py
@@ -211,7 +211,7 @@ class GnT(object):
         if self.opt_type == 'adam':
             for i in range(self.num_hidden_layers):
                 # input weights
-                if num_features_to_replace == 0:
+                if num_features_to_replace[i] == 0:
                     continue
                 self.opt.state[self.net[i * 2].weight]['exp_avg'][features_to_replace[i], :] = 0.0
                 self.opt.state[self.net[i * 2].bias]['exp_avg'][features_to_replace[i]] = 0.0


### PR DESCRIPTION
The variable num_features_to_replace is an array, making the condition num_features_to_replace == 0 incorrect and non-standard. 

This condition does not hold true in my tests with Python 3.12.7. To mitigate potential risks, I have modified the condition to num_features_to_replace[i] == 0 to properly index the array.

This change ensures that we are correctly accessing array elements and avoids the risk of unintended behavior or errors due to improper array indexing.